### PR TITLE
handle missing snapshot blocks

### DIFF
--- a/snapshot_backend.go
+++ b/snapshot_backend.go
@@ -146,9 +146,15 @@ func (sd *SnapshotBackend) readBlock(ctx context.Context, block int64) ([]byte, 
 			return v, nil
 		}
 
+		// if block is not present in snapshot, return zeros without caching
+		token, exists := sd.blockData.blockTokens[block]
+		if !exists {
+			return make([]byte, sd.metadata.blockSize), nil
+		}
+	
 		out, err := sd.client.GetSnapshotBlockWithContext(ctx, &ebs.GetSnapshotBlockInput{
 			BlockIndex: &block,
-			BlockToken: sd.blockData.blockTokens[block],
+			BlockToken: token,
 			SnapshotId: &sd.snapshot,
 		})
 		if err != nil {


### PR DESCRIPTION
first of all thanks for this tool, it proved handy :)

the current code assumes a snapshot has blocks in all indices, but this isn't necessarily true -- snapshots for a young machine may have block indices that are not returned in the ListSnapshotBlocks response. handle these by returning zeros rather than crashing.

it would also be nice to replace the command in `README` with one that [doesn't pull in the ceph libraries](https://github.com/abligh/gonbdserver/blob/9abaa2fed84fea02e090dbdd16be7bd20162e8b6/nbd/rbd.go#L3-L7), making the build shorter and not depending on the ceph stuff being installed in the system:

```
go install -tags noceph github.com/ebroder/ebuse@latest
```
